### PR TITLE
Trinket bonuses

### DIFF
--- a/commands/act.js
+++ b/commands/act.js
@@ -308,7 +308,7 @@ return;
 
 //If action has FIRST, makes sure its the first action taken this turn
   if(client.actionList[action[select]].add.includes("FIRST")){
-    if(list[pos][6].length > 0){
+    if(list[pos][6].length > 0 && !(list[pos][6].length == 1 && list[pos][6][0].substring(0,3) === "HAT")){
       message.channel.send("That ACTION can only be used if it is the first ACTION taken on a turn!");
       return;
     }

--- a/commands/strife.js
+++ b/commands/strife.js
@@ -146,7 +146,7 @@ if(client.traitcall.traitCheck(client,charid,"ROCKET")[0]){
   initRoll=20;
 }
 
-    let trinketBonus = client.strifecall.getBonusFromTrinket(client.charcall.charData(client, charid, "trinket")[0]);
+    let trinketBonus = client.strifecall.getBonusFromTrinket(client, message, client.charcall.charData(client, charid, "trinket")[0]);
     if(trinketBonus[1] === "initiative"){
 		initRoll += trinketBonus[0];
 	}
@@ -178,7 +178,7 @@ if(client.traitcall.traitCheck(client,charid,"ROCKET")[0]){
 
 
     //add all underlings in area to strife
-    strifecall.underRally(client,local);
+    strifecall.underRally(client,message,local);
     client.funcall.tick(client,message);
     message.channel.send("Entering Strife!");
 

--- a/commands/strife.js
+++ b/commands/strife.js
@@ -146,6 +146,11 @@ if(client.traitcall.traitCheck(client,charid,"ROCKET")[0]){
   initRoll=20;
 }
 
+    let trinketBonus = client.strifecall.getBonusFromTrinket(client.charcall.charData(client, charid, "trinket")[0]);
+    if(trinketBonus[1] === "initiative"){
+		initRoll += trinketBonus[0];
+	}
+
     var strifeSet = {
       list:[profile],
       init:[[0,initRoll]],

--- a/config.json
+++ b/config.json
@@ -40,6 +40,11 @@
       "desc" : "**What is the grist multiplier?**",
       "choices": ["x1","x2","x1/2 (warning, terrible)"],
       "selection": 0
+  },{
+      "name" : "TRINKETS",
+      "desc" : "**What bonuses are provided by trinkets?**",
+      "choices": ["No bonuses, only the traits","To-hit bonuses for all trinkets","To-hit for glasses, initiative for shoes, and occasional AV for hats."],
+      "selection": 0
   }
 ]
 }

--- a/modules/configcall.js
+++ b/modules/configcall.js
@@ -1,7 +1,13 @@
 exports.get = function(client, message, datatype){
-	datatype = datatype.toUpperCase();
-	let guildID = message.guild.id;
-	let retVal = "NONE"
+	return get(client, message.guild.id, datatype.toUpperCase());
+}
+
+exports.getWithGuildID = function(client, guildID, datatype){
+	return get(client, guildID, datatype.toUpperCase());
+}
+
+function get(client, guildID, datatype){
+	let retVal = "NONE";
 	
 	if(!client.configMap.has(guildID) || (client.configMap.get(guildID).settings == undefined)){
 		generateSettings(client, guildID);

--- a/modules/strifecall.js
+++ b/modules/strifecall.js
@@ -615,7 +615,7 @@ function startTurn(client, message, local) {
 //reset actions taken this turn
   list[init[turn][0]][6]=[];
   
-  let trinketBonus = getBonusFromTrinket(client.charcall.charData(client, list[init[turn][0]][PROFILE.CHARID], "trinket")[0]);
+  let trinketBonus = getBonusFromTrinket(client, message, client.charcall.charData(client, list[init[turn][0]][PROFILE.CHARID], "trinket")[0]);
   // 50% chance for the bonus AV to trigger for the round.
   if(trinketBonus[1] === "avChance" && Math.random() < 0.5){
 	  list[init[turn][0]][PROFILE.ACTION].push(`HAT${trinketBonus[0]}`);
@@ -955,7 +955,7 @@ exports.leaveStrife = function(client,message,local,target){
   leaveStrife(client,message,local,target);
 }
 
-exports.underRally = function(client, local) {
+exports.underRally = function(client, message, local) {
 //check if any underlings are in room, if so they will be added to the strife
   let sec = client.landMap.get(local[4],local[0]);
   let occList = sec[local[1]][local[2]][2][local[3]][4];
@@ -973,7 +973,7 @@ exports.underRally = function(client, local) {
       let list = client.strifeMap.get(strifeLocal,"list");
       let init = client.strifeMap.get(strifeLocal,"init");
       let active = client.strifeMap.get(strifeLocal,"active");
-	  let trinketBonus = getBonusFromTrinket(client.charcall.charData(client,occList[i][1],"trinket")[0]);
+	  let trinketBonus = getBonusFromTrinket(client, message, client.charcall.charData(client, occList[i][1],"trinket")[0]);
 
       var pos = list.length;
       client.charcall.setAnyData(client,'-',occList[i][1],pos,"pos");
@@ -1181,7 +1181,7 @@ targName = client.charcall.charData(client,list[target][1],"name");
   console.log(tarGrist);
 }
 
-    let trinketBonus = getBonusFromTrinket(client.charcall.charData(client,attUnit[1],"trinket")[0]);
+    let trinketBonus = getBonusFromTrinket(client, message, client.charcall.charData(client,attUnit[1],"trinket")[0]);
     if(trinketBonus[1] === "accuracy"){
 		strikeBonus += trinketBonus[0];
 	}
@@ -2429,22 +2429,31 @@ if(list[active[ik]][3] < 1){
   }
 }*/
 
-function getBonusFromTrinket(trinket){
-	if(trinket == undefined || trinket[1] == undefined){
+function getBonusFromTrinket(client, message, trinket){
+	let trinketSetting = client.configcall.get(client, message, "TRINKETS");
+	
+	if(trinketSetting == 0 || trinketSetting == "NONE" || trinket == undefined || trinket[1] == undefined){
 		return [0, "none"];
 	}
 	let tier = trinket[2];
 	let kind = trinket[1][0];
-	switch(kind){
-		case "t":	return [Math.floor(Math.sqrt(tier)), "initiative"];
-		case "u":	return [Math.floor(Math.sqrt(tier)), "avChance"];
-		case "v":	return [Math.floor(Math.sqrt(tier)), "accuracy"];
-		default:	return [0, "none"];
+	let bonus = Math.floor(Math.sqrt(tier));
+	if(trinketSetting == 1){
+		return [bonus, "accuracy"];
 	}
+	else if(trinketSetting == 2){
+		switch(kind){
+			case "t":	return [bonus, "initiative"];
+			case "u":	return [bonus, "avChance"];
+			case "v":	return [bonus, "accuracy"];
+			default:	return [0, "none"];
+		}
+	}
+	return [0, "none"];
 }
 
-exports.getBonusFromTrinket = function(trinket){
-	return getBonusFromTrinket(trinket);
+exports.getBonusFromTrinket = function(client, message, trinket){
+	return getBonusFromTrinket(client, message, trinket);
 }
 
 

--- a/modules/strifecall.js
+++ b/modules/strifecall.js
@@ -1520,7 +1520,7 @@ if(strikeBonus<0){
     av = av+2;
   }
   
-  if(targUnit[PROFILE.ACTION][0].substring(0,3) === "HAT"){
+  if(targUnit[PROFILE.ACTION][0] && targUnit[PROFILE.ACTION][0].substring(0,3) === "HAT"){
 	let hatBonus = parseInt(targUnit[PROFILE.ACTION][0].substring(3), 10);
 	if(!isNaN(hatBonus)){
 	  av += hatBonus;

--- a/modules/strifecall.js
+++ b/modules/strifecall.js
@@ -1155,6 +1155,13 @@ targName = client.charcall.charData(client,list[target][1],"name");
   console.log(grist);
   console.log(tarGrist);
 }
+
+    let trinketBonus = getBonusFromTrinket(client.charcall.charData(client,attUnit[1],"trinket")[0]);
+    if(trinketBonus[1] === "accuracy"){
+		strikeBonus += trinketBonus[0];
+	}
+
+
     //check for each action tag that is NONCOMBATIVE
     //PRE-ROLL ACT
     let pre;

--- a/modules/strifecall.js
+++ b/modules/strifecall.js
@@ -948,10 +948,14 @@ exports.underRally = function(client, local) {
       let list = client.strifeMap.get(strifeLocal,"list");
       let init = client.strifeMap.get(strifeLocal,"init");
       let active = client.strifeMap.get(strifeLocal,"active");
+	  let trinketBonus = getBonusFromTrinket(client.charcall.charData(client,occList[i][1],"trinket")[0]);
 
       var pos = list.length;
       client.charcall.setAnyData(client,'-',occList[i][1],pos,"pos");
       let initRoll = [pos, Math.floor((Math.random() * 20) + 1)];
+	  if(trinketBonus[1] === "initiative"){
+		initRoll += trinketBonus[0];
+	  }
 
       list.push(profile);
       active.push(pos);

--- a/modules/strifecall.js
+++ b/modules/strifecall.js
@@ -2384,6 +2384,26 @@ if(list[active[ik]][3] < 1){
 
   }
 }*/
+
+function getBonusFromTrinket(trinket){
+	if(trinket == undefined || trinket[1] == undefined){
+		return [0, "none"];
+	}
+	let tier = trinket[2];
+	let kind = trinket[1][0];
+	switch(kind){
+		case "t":	return [Math.floor(Math.sqrt(tier)), "initiative"];
+		case "u":	return [Math.floor(Math.sqrt(tier)), "avChance"];
+		case "v":	return [Math.floor(Math.sqrt(tier)), "accuracy"];
+		default:	return [0, "none"];
+	}
+}
+
+exports.getBonusFromTrinket = function(trinket){
+	return getBonusFromTrinket(trinket);
+}
+
+
 exports.spawn = function(client,message,underling,pregrist = false){
   let charid = client.userMap.get(message.guild.id.concat(message.author.id),"possess");
   let local = client.charcall.charData(client,charid,"local");


### PR DESCRIPTION
Trinkets offer bonuses based on their tier, in addition to the traits they possess. The bonus is 1 for tiers 1-3, 2 for tiers 4-8, 3 for tiers 9-15, and 4 for tier 16.
Glasses offer their bonus to accuracy, providing a to-hit bonus when rolling to attack.
Shoes offer a bonus to initiative when starting strife.
Hats offer a bonus to AV, but only on 50% of all turns.